### PR TITLE
Closes #1 and fixes error caused by missing import/loading statements

### DIFF
--- a/ncbitaxonomy/ncbi_taxonomy/__init__.py
+++ b/ncbitaxonomy/ncbi_taxonomy/__init__.py
@@ -37,3 +37,4 @@
 #
 # #END_LICENSE#############################################################
 from .ncbiquery import *
+from .ncbiquery2 import *

--- a/ncbitaxonomy/ncbi_taxonomy/ncbiquery2.py
+++ b/ncbitaxonomy/ncbi_taxonomy/ncbiquery2.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from . import ncbiquery
 
+__all__ = ["NCBITaxa"]
 
 RANKS = [
     "superkingdom",


### PR DESCRIPTION
Closes #1

This pull request fixes one of the two errors reported in epi2me-labs/tutorials#19. This error is associated with missing import/loading statements for the module `ncbiquery2`. Adding the respective statements will fix the issue.